### PR TITLE
Fix Windows Building

### DIFF
--- a/dumper/source/main.c
+++ b/dumper/source/main.c
@@ -6,6 +6,7 @@
 
 #ifdef _WIN32
 #include <direct.h>
+#define strcasecmp stricmp
 #else
 #include <sys/stat.h>
 #endif


### PR DESCRIPTION
strcasecmp doesn't exist on windows