### PR TITLE
Switch file stream to read binary so msf_header_read doesn't fail

### DIFF
--- a/dumper/source/main.c
+++ b/dumper/source/main.c
@@ -78,7 +78,7 @@ static void main_initialize(int argc, const char **argv)
     if (argc >= 4)
         sscanf(argv[3], "%" SCNx64, &main_globals.base_address);
 
-    FILE *pdb_file = fopen(main_globals.pdb_path, "r");
+    FILE *pdb_file = fopen(main_globals.pdb_path, "rb");
 
     if (!pdb_file)
     {


### PR DESCRIPTION
Stream is reading characters but when it finds a ASCII control character it ends stream. Switching to binary mode allows reading the control characters.

v7->signature = "Microsoft C/C++ MSF 7.00\n"

After fix

v7->signature 0x00007ff60eaae77c "Microsoft C/C++ MSF 7.00\r\n\x1aDS"