### PR TITLE
Fix Windows Path Parsing

### DIFF
--- a/shared/source/path.h
+++ b/shared/source/path.h
@@ -5,6 +5,7 @@ struct path
 {
     size_t component_count;
     char **components;
+    int has_protocol;
 };
 
 void path_dispose(struct path *path);

--- a/shared/source/utils.h
+++ b/shared/source/utils.h
@@ -25,6 +25,15 @@
         }                                                     \
     } while (0)
 
+/* ---------- min/max macros */
+
+#ifndef __min
+#define __min(a,b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef __max
+#define __max(a,b) (((a) > (b)) ? (a) : (b))
+#endif
+
 /* ---------- string functions */
 
 char *string_append(char **string, char *suffix);


### PR DESCRIPTION
When supplying an output path of A:\Output the path parsing doesn't account for Windows path nuances like a drive letter so it ends up outputting files to the root of the hard drive of the current working directory.

I haven't tested this outside of Windows either and don't have a machine setup at the moment so I'm not sure if I broke the Unix path system with this change so please test if plan to merge.